### PR TITLE
Added support for the SimpleSchema.Integer type

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ const getMockDoc = (schema, prefix) => {
           break;
 
         case Number:
+        case SimpleSchema.Integer:
           fieldValue = defField.min || defField.max || faker.random.number();
           break;
 

--- a/test.js
+++ b/test.js
@@ -62,6 +62,10 @@ const BasicSchemaWithMock = new SimpleSchema({
     type: Number,
     mockValue: 42,
   },
+  simpleSchemaIntegerField: {
+    type: SimpleSchema.Integer,
+    mockValue: 43
+  },
   objectField: {
     type: Object,
     mockValue: { bar: 'baz' },
@@ -88,6 +92,7 @@ const BasicSchemaWithMockObject = {
   booleanFieldFalse: false,
   dateField: new Date(86400000),
   numberField: 42,
+  simpleSchemaIntegerField: 43,
   objectField: { bar: 'baz' },
   stringFieldDefault: 'myValue',
   stringFieldAllowed: 'value1',


### PR DESCRIPTION
Fields with type [SimpleSchema.Integer](https://www.npmjs.com/package/simpl-schema#type) are being mocked to a null value when they should be set to faker.random.number() (which always returns an integer).